### PR TITLE
Update install instructions for fedora

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -56,12 +56,12 @@ yay -S prismlauncher-qt5-git
 
 You can replace yay -S with your preferred [AUR helper's](https://wiki.archlinux.org/title/AUR_helpers) install command.
 </div>
-
+<!--
 <div class="infobox top">
 
 # <img src="https://www.vectorlogo.zone/logos/centos/centos-icon.svg" height="20"> CentOS Stream / Red Hat Enterprise Linux
 
-Two RPM packages are available on [Copr](https://copr.fedorainfracloud.org/coprs/sentry/prismlauncher/).
+One RPM package is available on [Copr](https://copr.fedorainfracloud.org/coprs/sentry/prismlauncher/).
 
 ```bash
 # load in system information
@@ -75,7 +75,7 @@ sudo dnf install prismlauncher-nightly
 ```
 
 </div>
-  
+  -->
 <div class="infobox top">
 
 # <img src="https://www.vectorlogo.zone/logos/debian/debian-icon.svg" height="20" /> Debian / Ubuntu
@@ -122,22 +122,25 @@ una install prismlauncher-git
 You can replace una install with your preferred [MPR helper's](https://docs.makedeb.org/using-the-mpr/list-of-mpr-helpers/) install command.
 </div>
 
-<!--
+
 <div class="infobox top">
 
 # <img src="https://www.vectorlogo.zone/logos/getfedora/getfedora-icon.svg" height="20"> Fedora
 
-Two RPM packages are available on [Copr](https://copr.fedorainfracloud.org/coprs/sentry/prismlauncher/).
+One RPM package is available on [Copr](https://copr.fedorainfracloud.org/coprs/g3tchoo/prismlauncher/).
 
 ```bash
 # enables the copr repo
-sudo dnf copr enable sentry/prismlauncher
-# stable releases
-sudo dnf install prismlauncher
+sudo dnf copr enable g3tchoo/prismlauncher
 # nightly releases (git master)
-sudo dnf install prismlauncher-nightly
+sudo dnf install prismlauncher
 ```
-
+<!-- 
+  # nightly releases (git master)
+sudo dnf install prismlauncher-nightly 
+  -->
+  
+<!--
 </div>
 <div class="infobox top">
 


### PR DESCRIPTION
There is a Copr repository available for Fedora 35 - Rawhide and OpenSuse tumbleweed, however the repository is lacking the Leap branch of OpenSuse. It should be placed into the OBS or games:tools repository some time in the near future. CentOS and RHEL don't have any packages available (to my current knowledge). As you have to manually download the .repo file in OpenSuse, OpenSuse instructions won't be included in this pr.

This was created to save new people (yk flooding in) from not being able to install Prism Launcher without having to surf through the discord server. 

Signed-off-by: Ascende Supirius <92772508+LackingCats@users.noreply.github.com>